### PR TITLE
cleaning up instrumentation of `subscribe` function (#5)

### DIFF
--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -20,8 +20,18 @@ pub struct FormData {
     )
 )]
 pub async fn subscribe(form: web::Form<FormData>, pool: web::Data<PgPool>) -> HttpResponse {
-    let query_span = tracing::info_span!("Saving new subscriber details in thd database.");
-    match sqlx::query!(
+    match insert_subscribe(&pool, &form).await {
+        Ok(_) => HttpResponse::Ok().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[tracing::instrument(
+    name = "Saving new subscriber details in the database",
+    skip(form, pool)
+)]
+pub async fn insert_subscribe(pool: &PgPool, form: &FormData) -> Result<(), sqlx::Error> {
+    sqlx::query!(
         r#"
     INSERT INTO subscriptions (id, email, name, subscribed_at)
     VALUES ($1, $2, $3, $4)
@@ -31,14 +41,11 @@ pub async fn subscribe(form: web::Form<FormData>, pool: web::Data<PgPool>) -> Ht
         form.name,
         Utc::now()
     )
-    .execute(pool.get_ref())
-    .instrument(query_span) // まず instrumentation をアタッチし、
-    .await                  // `.await` する
-    {
-        Ok(_) => HttpResponse::Ok().finish(),
-        Err(e) => {
-            tracing::error!("Failed to execute query: {:?}", e);
-            HttpResponse::InternalServerError().finish()
-        }
-    }
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+    Ok(())
 }


### PR DESCRIPTION
`tracing` の手続き型マクロ `#[instrument]` を使って、

- `subscribe` 関数を span で囲むように修正
- クエリを関数に切り出し、これも span で囲むことで `query_span` と `.instrument` の呼び出しを削除するように修正