### PR TITLE
fix (#11) by using offline mode for `sqlx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,9 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1729,9 +1732,12 @@ dependencies = [
  "dotenv",
  "either",
  "heck",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ config = { version = "0.13.1", default-features = false, features = ["yaml"] }
 once_cell = "1.10.0"
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde = "1.0.137"
-sqlx = { version = "0.5.5", default-features = false, features = ["runtime-actix-rustls", "macros", "postgres", "uuid", "chrono", "migrate"] }
+sqlx = { version = "0.5.5", default-features = false, features = ["runtime-actix-rustls", "macros", "postgres", "uuid", "chrono", "migrate", "offline"] }
 tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-actix-web = "0.5.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt update && apt install lld clang -y
 
 COPY . .
 
+ENV SQLX_OFFLINE true
+
 RUN cargo build --release
 
 ENTRYPOINT [ "./target/release/newsletter" ]

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,0 +1,18 @@
+{
+  "db": "PostgreSQL",
+  "793f0df728d217c204123f12e4eafd6439db2d49d0cb506618ae9e780c7e0558": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text",
+          "Timestamptz"
+        ]
+      }
+    },
+    "query": "\n    INSERT INTO subscriptions (id, email, name, subscribed_at)\n    VALUES ($1, $2, $3, $4)\n            "
+  }
+}


### PR DESCRIPTION
### `sqlx` の offline モードを使うことで解決

1. `Cargo.toml` の `sqlx` の features に `offline` を追加

```toml
#! Cargo.toml
# [...]

sqlx = { version = "0.5.5", default-features = false, features = ["...", "offline"] }
```

2. `sqlx` のCLIを利用

```
$ cargo sqlx prepare -- --lib
```

```
query data written to `sqlx-data.json` in the current directory; please check this into version control
```

メタデータが記述された `sqlx-data.json` が生成される

3. Dockerfile の `SQLX_OFFLINE` 環境変数を `true` に設定

```Dockerfile
FROM rust:1.60.0

WORKDIR /app
RUN apt update && apt install lld clang -y
COPY . .
ENV SQLX_OFFLINE true    # 追加
RUN cargo build --release
ENTRYPOINT [ "./target/release/newsletter" ]
```

4. build 実行

```
$ docker build --tag newsletter --file Dockerfile .
```