### PR TITLE
relax the requirement by using `connect_lazy` (#13)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,7 @@ async fn main() -> std::io::Result<()> {
 
     let configuration = get_configuration().expect("Failed to read configuration.");
     let connection_pool =
-        PgPool::connect(configuration.database.connection_string().expose_secret())
-            .await
+        PgPool::connect_lazy(configuration.database.connection_string().expose_secret())
             .expect("Failed to connect to Postgres.");
     let address = format!("127.0.0.1:{}", configuration.application_port);
     let listener = TcpListener::bind(address)?;


### PR DESCRIPTION
`connect_lazy` を使うことで要件を緩和し解決
`-> プールが初めて使用されるときのみ接続を確立しようとする